### PR TITLE
Fix: Correct distance display for POIs

### DIFF
--- a/client/src/lib/mapUtils.ts
+++ b/client/src/lib/mapUtils.ts
@@ -2,8 +2,8 @@ import { Coordinates } from '@/types/navigation';
 import { calculateDistance as calcDistanceMeters, formatDistance as formatDistanceShared, toRadians } from '../../../shared/utils';
 
 export const calculateDistance = (point1: Coordinates, point2: Coordinates): number => {
-  // Convert from meters to kilometers for backward compatibility
-  return calcDistanceMeters(point1.lat, point1.lng, point2.lat, point2.lng) / 1000;
+  // Return distance in meters, as expected by formatDistance
+  return calcDistanceMeters(point1.lat, point1.lng, point2.lat, point2.lng);
 };
 
 export const formatDistance = (distanceInMeters: number): string => {


### PR DESCRIPTION
The distance to a POI was incorrectly displayed as "0 Meter" for distances under 1km.

This was caused by a unit conversion error in `client/src/lib/mapUtils.ts`. The `calculateDistance` function was converting the result to kilometers, while the `formatDistance` function expected the input to be in meters. This caused any distance less than 1km to be rounded down to 0.

The fix removes the incorrect division by 1000 in `calculateDistance`, ensuring it returns meters as expected by the formatting function.