### PR TITLE
Fix(TTS): Correct navigation start announcement logic

### DIFF
--- a/client/src/pages/Navigation.tsx
+++ b/client/src/pages/Navigation.tsx
@@ -1280,10 +1280,19 @@ export default function Navigation() {
         }
       );
 
-      // Set initial instruction
+      // Set initial instruction and announce it
       if (currentRoute.instructions.length > 0) {
-        setCurrentInstruction(currentRoute.instructions[0].instruction);
+        const firstInstructionText = currentRoute.instructions[0].instruction;
+        setCurrentInstruction(firstInstructionText);
         setNextDistance(currentRoute.instructions[0].distance);
+
+        // CRITICAL FIX: Announce the first instruction immediately
+        if (secureTTSRef.current && voiceEnabled) {
+          console.log('🎤 ElevenLabs Initial Route TTS:', firstInstructionText);
+          secureTTSRef.current.speak(firstInstructionText, 'start').catch(err =>
+            console.error('Initial TTS Error:', err)
+          );
+        }
       }
     }
 


### PR DESCRIPTION
This commit fixes a bug where users would hear either a double voice announcement or no announcement at all when starting navigation.

Previously, a generic "Navigation gestartet" message was fired from the UI event handlers, and the `RouteTracker` was supposed to announce the first instruction. This led to a race condition and confusing audio cues.

The fix implements the following changes:
1.  Removes the redundant "Navigation gestartet" TTS calls from `handleNavigateToPOI` and `handleDestinationLongPress`.
2.  Adds logic to the `useEffect` hook that initializes the `RouteTracker`. This new logic explicitly speaks the first turn-by-turn instruction as soon as the route is calculated.

This ensures a single, timely, and correct announcement is made at the start of every navigation session.