### PR TITLE
feat(nav): implement live debugging toolkit

### DIFF
--- a/client/src/components/Navigation/DebugInfoPanel.tsx
+++ b/client/src/components/Navigation/DebugInfoPanel.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { RouteProgress } from '@/lib/routeTracker';
+
+interface DebugInfoPanelProps {
+  debugInfo: RouteProgress | null;
+  reroutingCooldown: boolean;
+}
+
+const DebugDataItem: React.FC<{ label: string; value: string | number | undefined }> = ({ label, value }) => (
+  <div className="flex justify-between text-xs">
+    <span className="font-semibold">{label}:</span>
+    <span className="font-mono">{value === undefined ? 'N/A' : value}</span>
+  </div>
+);
+
+export const DebugInfoPanel: React.FC<DebugInfoPanelProps> = ({ debugInfo, reroutingCooldown }) => {
+  if (!debugInfo) {
+    return null;
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        bottom: '80px',
+        left: '10px',
+        width: '250px',
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        color: 'white',
+        padding: '8px',
+        borderRadius: '8px',
+        zIndex: 1100,
+        fontFamily: 'sans-serif',
+      }}
+    >
+      <h4 className="text-sm font-bold mb-2 border-b border-gray-500 pb-1">Debug Info</h4>
+      <div className="space-y-1">
+        <DebugDataItem label="Current Step" value={`${(debugInfo.currentStep || 0) + 1}`} />
+        <DebugDataItem label="Dist to Next" value={`${(debugInfo.distanceToNext * 1000).toFixed(1)}m`} />
+        <DebugDataItem label="Off-Route Dist" value={`${(debugInfo.offRouteDistance || 0).toFixed(1)}m`} />
+        <DebugDataItem label="Is Off-Route" value={debugInfo.isOffRoute ? 'YES' : 'NO'} />
+        <DebugDataItem label="Reroute Cooldown" value={reroutingCooldown ? 'YES' : 'NO'} />
+        <DebugDataItem label="Raw Lat" value={debugInfo.rawGpsPosition?.lat.toFixed(6)} />
+        <DebugDataItem label="Raw Lng" value={debugInfo.rawGpsPosition?.lng.toFixed(6)} />
+        <DebugDataItem label="Snapped Lat" value={debugInfo.snappedGpsPosition?.lat.toFixed(6)} />
+        <DebugDataItem label="Snapped Lng" value={debugInfo.snappedGpsPosition?.lng.toFixed(6)} />
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/Navigation/DebugOverlay.tsx
+++ b/client/src/components/Navigation/DebugOverlay.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { useMap } from 'react-leaflet';
+import L from 'leaflet';
+import { Coordinates } from '@/types/navigation';
+
+interface DebugOverlayProps {
+  rawGpsPosition?: Coordinates | null;
+  snappedGpsPosition?: Coordinates | null;
+  rerouteThreshold?: number; // in meters
+  networkGeoJson?: any;
+}
+
+export const DebugOverlay: React.FC<DebugOverlayProps> = ({
+  rawGpsPosition,
+  snappedGpsPosition,
+  rerouteThreshold = 5,
+  networkGeoJson,
+}) => {
+  const map = useMap();
+
+  React.useEffect(() => {
+    const layers = new L.LayerGroup();
+
+    // Raw GPS Position (Red Dot)
+    if (rawGpsPosition) {
+      L.circleMarker([rawGpsPosition.lat, rawGpsPosition.lng], {
+        radius: 6,
+        color: 'red',
+        fillColor: '#f03',
+        fillOpacity: 0.8,
+      }).addTo(layers);
+    }
+
+    // Routing Network GeoJSON
+    if (networkGeoJson) {
+      L.geoJSON(networkGeoJson, {
+        style: {
+          color: '#888',
+          weight: 2,
+          opacity: 0.6,
+        },
+      }).addTo(layers);
+    }
+
+    // Snapped GPS Position (Green Dot)
+    if (snappedGpsPosition) {
+      L.circleMarker([snappedGpsPosition.lat, snappedGpsPosition.lng], {
+        radius: 6,
+        color: 'green',
+        fillColor: '#28a745',
+        fillOpacity: 0.8,
+      }).addTo(layers);
+    }
+
+    // Re-route Threshold Circle (Blue Circle)
+    if (snappedGpsPosition) {
+        L.circle([snappedGpsPosition.lat, snappedGpsPosition.lng], {
+        radius: rerouteThreshold,
+        color: '#007bff',
+        fillOpacity: 0.1,
+        weight: 2,
+        dashArray: '5, 5',
+      }).addTo(layers);
+    }
+
+    layers.addTo(map);
+
+    return () => {
+      map.removeLayer(layers);
+    };
+  }, [map, rawGpsPosition, snappedGpsPosition, rerouteThreshold, networkGeoJson]);
+
+  return null; // This component only adds layers to the map, it doesn't render any DOM elements itself.
+};

--- a/client/src/components/Navigation/EnhancedMapControls.tsx
+++ b/client/src/components/Navigation/EnhancedMapControls.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { Volume2, VolumeX, Layers, Navigation, Car, Bike, PersonStanding, Compass, Settings, Mic } from 'lucide-react';
+import { Volume2, VolumeX, Layers, Navigation, Car, Bike, PersonStanding, Compass, Settings, Mic, Bug } from 'lucide-react';
 import { GPSToggle } from './GPSToggle';
 import { VoiceSelection } from './VoiceSelection';
 import { VoiceControlPanel } from './VoiceControlPanel';
+
+const isDev = process.env.NODE_ENV === 'development';
 
 interface EnhancedMapControlsProps {
   onToggleVoice: () => void;
@@ -21,6 +23,8 @@ interface EnhancedMapControlsProps {
   onToggleCompass: () => void;
   showNetworkOverlay: boolean;
   onToggleNetworkOverlay: () => void;
+  isDebugMode: boolean;
+  onToggleDebugMode: () => void;
 }
 
 const mapStyleConfig = {
@@ -186,6 +190,14 @@ export const EnhancedMapControls: React.FC<EnhancedMapControlsProps> = ({
           <Layers className="w-5 h-5 text-white" />,
           showNetworkOverlay ? 'Netzwerk-Overlay ausblenden' : 'Netzwerk-Overlay anzeigen',
           showNetworkOverlay
+        )}
+
+        {/* Debug Mode Toggle - Only in Dev */}
+        {isDev && renderControlButton(
+          onToggleDebugMode,
+          <Bug className="w-5 h-5 text-white" />,
+          isDebugMode ? 'Debug-Modus deaktivieren' : 'Debug-Modus aktivieren',
+          isDebugMode
         )}
       </div>
 

--- a/client/src/lib/routeTracker.ts
+++ b/client/src/lib/routeTracker.ts
@@ -13,6 +13,10 @@ export interface RouteProgress {
   currentSpeed: number;
   averageSpeed: number;
   dynamicETA: ETAUpdate;
+  // Debugging fields
+  rawGpsPosition?: Coordinates;
+  snappedGpsPosition?: Coordinates;
+  offRouteDistance?: number;
 }
 
 export class RouteTracker {
@@ -253,7 +257,7 @@ export class RouteTracker {
     // Estimate remaining time based on speed tracking
     const estimatedTimeRemaining = dynamicETA.estimatedTimeRemaining;
 
-    const progress = {
+    const progress: RouteProgress = {
       currentStep: this.currentStepIndex,
       distanceToNext,
       distanceRemaining,
@@ -263,7 +267,11 @@ export class RouteTracker {
       estimatedTimeRemaining,
       currentSpeed: speedData.currentSpeed,
       averageSpeed: speedData.averageSpeed,
-      dynamicETA
+      dynamicETA,
+      // Add debug info
+      rawGpsPosition: position,
+      snappedGpsPosition: routeInfo.point,
+      offRouteDistance: routeInfo.distance,
     };
     
     console.log('🗺️ ROUTE TRACKER: Progress calculated:', {


### PR DESCRIPTION
This commit introduces a comprehensive debugging toolkit for the navigation component to aid in root cause analysis of turn-by-turn and re-routing issues.

The toolkit is only available in the development environment and can be toggled via a new 'bug' icon in the map controls.

Features include:
- A `DebugOverlay` component that visually represents on the map:
  - Raw vs. snapped GPS positions (red and green dots).
  - A 5-meter circle to visualize the re-routing threshold.
  - The entire underlying GeoJSON routing network for the current location.
- A `DebugInfoPanel` component that displays live data in a floating panel, including the current step, off-route distance, and cooldown status.
- The `RouteTracker` has been updated to expose this detailed debug information.
- The `Navigation` page now manages the state for the debug mode and passes the necessary data to the new components.