### PR TITLE
Fix(nav): Correct props destructuring for debug toggle

### DIFF
--- a/client/src/components/Navigation/EnhancedMapControls.tsx
+++ b/client/src/components/Navigation/EnhancedMapControls.tsx
@@ -55,7 +55,9 @@ export const EnhancedMapControls: React.FC<EnhancedMapControlsProps> = ({
   compassMode,
   onToggleCompass,
   showNetworkOverlay,
-  onToggleNetworkOverlay
+  onToggleNetworkOverlay,
+  isDebugMode,
+  onToggleDebugMode
 }) => {
   const [showVoicePanel, setShowVoicePanel] = useState(false);
   const mapStyleOptions = Object.entries(mapStyleConfig) as [keyof typeof mapStyleConfig, typeof mapStyleConfig[keyof typeof mapStyleConfig]][];


### PR DESCRIPTION
This commit fixes a runtime error 'onToggleDebugMode is not defined' in the `EnhancedMapControls` component.

The `isDebugMode` and `onToggleDebugMode` props were being passed to the component but were not being destructured from the props object in the component's function signature, making them unavailable in the component's scope.

This has now been corrected, and the debug toolkit should be fully functional in the development environment.