### PR TITLE
Fix(debug): Correct bugs in navigation debug toolkit

### DIFF
--- a/client/src/components/Navigation/DebugInfoPanel.tsx
+++ b/client/src/components/Navigation/DebugInfoPanel.tsx
@@ -37,7 +37,7 @@ export const DebugInfoPanel: React.FC<DebugInfoPanelProps> = ({ debugInfo, rerou
       <div className="space-y-1">
         <DebugDataItem label="Current Step" value={`${(debugInfo.currentStep || 0) + 1}`} />
         <DebugDataItem label="Dist to Next" value={`${(debugInfo.distanceToNext * 1000).toFixed(1)}m`} />
-        <DebugDataItem label="Off-Route Dist" value={`${(debugInfo.offRouteDistance || 0).toFixed(1)}m`} />
+        <DebugDataItem label="Off-Route Dist" value={`${((debugInfo.offRouteDistance || 0) * 1000).toFixed(1)}m`} />
         <DebugDataItem label="Is Off-Route" value={debugInfo.isOffRoute ? 'YES' : 'NO'} />
         <DebugDataItem label="Reroute Cooldown" value={reroutingCooldown ? 'YES' : 'NO'} />
         <DebugDataItem label="Raw Lat" value={debugInfo.rawGpsPosition?.lat.toFixed(6)} />

--- a/client/src/components/Navigation/DebugOverlay.tsx
+++ b/client/src/components/Navigation/DebugOverlay.tsx
@@ -21,17 +21,7 @@ export const DebugOverlay: React.FC<DebugOverlayProps> = ({
   React.useEffect(() => {
     const layers = new L.LayerGroup();
 
-    // Raw GPS Position (Red Dot)
-    if (rawGpsPosition) {
-      L.circleMarker([rawGpsPosition.lat, rawGpsPosition.lng], {
-        radius: 6,
-        color: 'red',
-        fillColor: '#f03',
-        fillOpacity: 0.8,
-      }).addTo(layers);
-    }
-
-    // Routing Network GeoJSON
+    // Routing Network GeoJSON (drawn first, as a base layer)
     if (networkGeoJson) {
       L.geoJSON(networkGeoJson, {
         style: {
@@ -39,6 +29,16 @@ export const DebugOverlay: React.FC<DebugOverlayProps> = ({
           weight: 2,
           opacity: 0.6,
         },
+      }).addTo(layers);
+    }
+
+    // Raw GPS Position (Red Dot)
+    if (rawGpsPosition) {
+      L.circleMarker([rawGpsPosition.lat, rawGpsPosition.lng], {
+        radius: 6,
+        color: 'red',
+        fillColor: '#f03',
+        fillOpacity: 0.8,
       }).addTo(layers);
     }
 


### PR DESCRIPTION
This commit fixes two bugs that were identified during the testing of the new navigation debug toolkit:

1.  **Incorrect Distance Unit:** The `offRouteDistance` in the `DebugInfoPanel` was being displayed in kilometers instead of meters. This has been corrected by applying the same `* 1000` multiplication that was used for other distance values.

2.  **Missing Map Overlays:** The debug markers and circles (raw/snapped GPS positions and re-route threshold) were not appearing on the map. This was caused by the large GeoJSON network layer being rendered on top of them. The drawing order in the `DebugOverlay` component has been corrected to render the network layer first, ensuring the markers are always visible on top.

With these fixes, the debug toolkit is now fully functional.